### PR TITLE
add: start-stop-daemon, readme, status, support other options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM centos:7
+MAINTAINER Ahmet Demir <ahmet2mir+github@gmail.com>
+
+ENV SHELL /bin/bash
+
+# install gcc
+RUN yum install -y gcc
+
+RUN curl https://raw.githubusercontent.com/daleobrien/start-stop-daemon/master/start-stop-daemon.c > start-stop-daemon.c \
+    &&  gcc start-stop-daemon.c -o start-stop-daemon \
+    &&  mv start-stop-daemon /usr/bin/start-stop-daemon
+
+ADD systemctl /usr/bin/systemctl-fake
+RUN mv /usr/bin/systemctl /usr/bin/systemctl.real \
+    && ln -s /usr/bin/systemctl-fake /usr/bin/systemctl
+
+RUN yum clean all

--- a/README.md
+++ b/README.md
@@ -1,0 +1,167 @@
+# Fake Systemd
+
+From https://github.com/kvaps/fake-systemd and using Debian like start-stop-deamon from https://github.com/daleobrien/start-stop-daemon written by Marek Michalkiewicz <marekm@i17linuxb.ists.pwr.wroc.pl>.
+
+Instead of using original systemctl + dbus + priviliges + seccomp + x packages + conjunction of mercury and venus, a simple bash script using start-stop-daemon.
+
+## Usage
+
+The container will only compile start-stop-daemon and put the file in systemctl.
+Build
+
+    $ docker build -t ahmet2mir/fakesystemd .
+
+Run interactive docker
+
+    $ docker run --rm -it ahmet2mir/fakesystemd bash
+
+Example with httpd
+
+```
+[root@ff6625414fd4 /]# yum install httpd -y
+[root@ff6625414fd4 /]# systemctl start httpd
+
+[root@ff6625414fd4 ~]# systemctl status httpd 
+● httpd.service - The Apache HTTP Server
+   Loaded: loaded (/usr/lib/systemd/system/httpd.service; disabled; vendor preset: not_implemented)
+   Active: active (running) since Tue Oct 24 09:23:20 2017
+/usr/bin/systemctl: line 236: [: man:httpd(8): binary operator expected
+ Main PID: 5977 (httpd)
+   Memory: 0.0%
+   CGroup: /system.slice/httpd.service
+           └─5977 /usr/sbin/httpd -DFOREGROUND
+
+[root@ff6625414fd4 ~]# curl -XHEADER localhost
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html><head>
+<title>501 Not Implemented</title>
+</head><body>
+<h1>Not Implemented</h1>
+<p>HEADER to / not supported.<br />
+</p>
+</body></html>
+
+[root@ff6625414fd4 ~]# systemctl stop httpd  
+[root@ff6625414fd4 ~]# curl -XHEADER localhost
+curl: (7) Failed connect to localhost:80; Connection refused
+
+[root@ff6625414fd4 ~]# systemctl enable httpd
+Created symlink from /etc/systemd/system/multi-user.target.wants/httpd.service to /usr/lib/systemd/system/httpd.service.
+[root@ff6625414fd4 ~]# systemctl is-enabled httpd
+enabled
+[root@ff6625414fd4 ~]# systemctl is-active httpd
+failed
+[root@ff6625414fd4 ~]# systemctl status httpd
+● httpd.service - The Apache HTTP Server
+   Loaded: loaded (/usr/lib/systemd/system/httpd.service; enabled; vendor preset: not_implemented)
+   Active: failed (Result: not_implemented)
+[root@ff6625414fd4 ~]# systemctl start httpd
+[root@ff6625414fd4 ~]# systemctl is-active httpd
+active
+```
+
+Example with sshd
+
+```
+[root@ff6625414fd4 ~]# yum install -y openssh-clients openssh-server sshpass
+[root@ff6625414fd4 ~]# systemctl start sshd
+[root@ff6625414fd4 ~]# systemctl status sshd
+● sshd.service - OpenSSH server daemon
+   Loaded: loaded (/usr/lib/systemd/system/sshd.service; disabled; vendor preset: not_implemented)
+   Active: active (running) since Tue Oct 24 09:27:30 2017
+/usr/bin/systemctl: line 236: [: man:sshd(8): binary operator expected
+ Main PID: 7189 (sshd)
+   Memory: 0.0%
+   CGroup: /system.slice/sshd.service
+           └─7189 /usr/sbin/sshd -D
+
+[root@ff6625414fd4 ~]# echo "root:docker" | chpasswd 
+[root@ff6625414fd4 ~]# sshpass -p docker ssh -oStrictHostKeyChecking=no localhost uptime
+ 09:29:28 up 5 days, 18:14,  0 users,  load average: 0.00, 0.02, 0.05
+```
+
+## Currently supported actions
+
+**Unit Commands:**
+
+* start
+* stop
+* restart
+* is-active
+* status: works with the pidfile,  if a PIDfile options isn't defined, one will be created in /run/UNIT_NAME.pid.
+
+**Unit File Commands:**
+
+* enable
+* disable
+* is-enabled 
+
+**Variables:**
+
+* MAINPID
+
+**Specifiers:**
+
+* %i
+* %I
+* %n
+* %N
+
+**Unit Options:**
+
+* Description
+* Documentation
+
+**Install Options:**
+
+* WantedBy
+
+**Service Options:**
+
+* EnvironmentFile: if starting with a minus/dash (ex EnvironmentFile=-/etc/sysconfig/myconfig), errors are ignored
+* ExecStart
+* ExecStartPost
+* ExecStartPre
+* ExecStop
+* ExecStopPost
+* ExecStopPre
+* PIDFile
+* Type (oneshot, simple, notify and forking only)
+* User
+* WorkingDirectory
+
+`Exec[Start|Stop][Post|Pre]` commands with `\` and multiples occurrence are supported well.
+If a command starts with a minus/dash, the error is ignored.
+
+# Licences
+
+`Original fake-systemd` Copyright (c) 2017 kvaps Licence MIT https://opensource.org/licenses/MIT
+
+`start-stop-daemon` is under public domain, see https://github.com/daleobrien/start-stop-daemon#notes
+
+```
+A rewrite of the original Debian's start-stop-daemon Perl script
+in C (faster - it is executed many times during system startup).
+
+Written by Marek Michalkiewicz <marekm@i17linuxb.ists.pwr.wroc.pl>,
+public domain.  Based conceptually on start-stop-daemon.pl, by Ian
+Jackson <ijackson@gnu.ai.mit.edu>.  May be used and distributed
+freely for any purpose.  Changes by Christian Schwarz
+<schwarz@monet.m.isar.de>, to make output conform to the Debian
+Console Message Standard, also placed in public domain.  Minor
+changes by Klee Dienes <klee@debian.org>, also placed in the Public
+Domain.
+
+Changes by Ben Collins <bcollins@debian.org>, added --chuid, --background
+and --make-pidfile options, placed in public domain aswell.
+
+Port to OpenBSD by Sontri Tomo Huynh <huynh.29@osu.edu>
+               and Andreas Schuldei <andreas@schuldei.org>
+Changes by Ian Jackson: added --retry (and associated rearrangements).
+
+Modified for Gentoo rc-scripts by Donny Davies <woodchip@gentoo.org>:
+ I removed the BSD/Hurd/OtherOS stuff, added #include <stddef.h>
+ and stuck in a #define VERSION "1.9.18".  Now it compiles without
+ the whole automake/config.h dance.
+```
+    

--- a/systemctl
+++ b/systemctl
@@ -1,158 +1,172 @@
 #!/bin/bash
+# upper vars:     like UNIT* are in exec_action context
+# lower vars:     in local function
+# camelcase vars: systemd params var
 
 function get_unit_file(){
-    
-     local UNIT=$1
-
-     for DIR in ${UNIT_PATHS[@]} ; do
-         if [ -f "${DIR}${UNIT}" ] ; then
-             echo "${DIR}${UNIT}"
-             break
-         fi
-     done
-
+    for dir in ${UNIT_PATHS[@]} ; do
+        if [ -f "${dir}${UNIT}" ] ; then
+            echo "${dir}${UNIT}"
+            break
+        fi
+    done
 }
 
 function read_option(){
-     local OPTION="$1"
-     local UNIT_FILE="$2"
-     local UNIT_INSTANCE="$3"
+    local option="$1"
+    value="$(grep '^'$option'[= ]' "$UNIT_FILE" | cut -d '=' -f2- | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    value="`
+        echo $value |
+        sed -e "s/%[i]/$UNIT_INSTANCE/g" \
+            -e "s/%[I]/\"$UNIT_INSTANCE\"/g" \
+            -e "s/%[n]/$UNIT_FULL/g" \
+            -e "s/%[N]/\"$UNIT_FULL\"/g"
+    `"
+    # TODO: Add more options from:
+    # https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Specifiers
 
-     local UNIT=`basename $UNIT_FILE`
-     local UNIT_FULL=`echo $UNIT | sed "s/@/@$UNIT_INSTANCE/"`
+    echo $value
+}
 
-     VALUE="$(grep '^'$OPTION'[= ]' "$UNIT_FILE" | cut -d '=' -f2- | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+function read_multioption(){
+    local option="$1"
 
-     VALUE="`
-         echo $VALUE |
-         sed -e "s/%[i]/$UNIT_INSTANCE/g" \
-             -e "s/%[I]/\"$UNIT_INSTANCE\"/g" \
-             -e "s/%[n]/$UNIT_FULL/g" \
-             -e "s/%[N]/\"$UNIT_FULL\"/g"
-     `"
-     # TODO: Add more options from:
-     # https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Specifiers
+    while IFS= read -r line; do
+        echo "$line" |
+            sed -e "s/%[i]/$UNIT_INSTANCE/g" \
+                -e "s/%[I]/\"$UNIT_INSTANCE\"/g" \
+                -e "s/%[n]/$UNIT_FULL/g" \
+                -e "s/%[N]/\"$UNIT_FULL\"/g"
+    done < <( sed ':a;N;$!ba;s/\\[[:space:]]*\n//g' "$UNIT_FILE" | grep '^'$option'[= ]' | cut -d '=' -f2- | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' )
 
-     echo $VALUE
+    # TODO: Add more options from:
+    # https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Specifiers
 }
 
 function get_unit_wants() {
-
-     local UNIT_FILE=$1
-     local UNIT=`basename $UNIT_FILE`
-
-     sort -u <<< `(
-         # Print wants from UNIT_PATHS
-         for DIR in ${UNIT_PATHS[@]} ; do
-             if [ -d "${DIR}${UNIT}.wants" ] ; then
-                 ls -1 "${DIR}${UNIT}.wants/" | tr '\n' ' '
-             fi
-         done
+    sort -u <<< `(
+        # Print wants from UNIT_PATHS
+        for DIR in ${UNIT_PATHS[@]} ; do
+            if [ -d "${DIR}${UNIT}.wants" ] ; then
+                ls -1 "${DIR}${UNIT}.wants/" | tr '\n' ' '
+            fi
+        done
     
-         # Print wants from unit-file
-         read_option Wants $UNIT_FILE
-     )`
+        # Print wants from unit-file
+        read_option Wants $UNIT_FILE
+    )`
 }
 
 function action_start(){
-
-    # Find depended services
-    local UNIT_FILE=$1
-    local UNIT_WANTS=(`get_unit_wants $1`)
-    local UNIT_INSTANCE=$2
-
     # Start depended services
-    for UNIT in ${UNIT_WANTS[@]}; do
-        exec_action start $UNIT
+    for unit in ${UNIT_WANTS[@]}; do
+        exec_action start $unit
     done
 
     # Load options 
-    local User=`read_option User $UNIT_FILE $UNIT_INSTANCE`
-    local Type=`read_option Type $UNIT_FILE $UNIT_INSTANCE`
-    local EnvironmentFile=`read_option EnvironmentFile $UNIT_FILE $UNIT_INSTANCE`
-    local ExecStartPre=(`read_option ExecStartPre $UNIT_FILE $UNIT_INSTANCE`)
-    local ExecStart=`read_option ExecStart $UNIT_FILE $UNIT_INSTANCE`
-    local ExecStartPost=(`read_option ExecStartPost $UNIT_FILE $UNIT_INSTANCE`)
+    local User=$(read_option User)
+    local Type=$(read_option Type)
+    local PIDFile=$(read_option PIDFile)
+    local EnvironmentFile=$(read_option EnvironmentFile | sed 's/^-//')
+    local WorkingDirectory=($(read_option WorkingDirectory))
+    local ExecStart=($(read_option ExecStart))
+    local ExecStartPre=$(read_multioption ExecStartPre)
+    local ExecStartPost=$(read_multioption ExecStartPost)
 
-    [ -f "$EnvironmentFile" ] && source "$EnvironmentFile"
+    # From doc: oneshot are the only service units that may have more than one
+    # ExecStart= specified. They will be executed in order until either they
+    # are all successful or one of them fails.
+    # Note that systemd will consider the unit to be in the state "starting"
+    # until the program has terminated, so ordered dependencies will wait 
+    # for the program to finish before starting themselves. The unit will 
+    # revert to the "inactive" state after the execution is done, never
+    # reaching the "active" state. That means another request to start
+    # the unit will perform the action again.
+    if [[ "${Type,,}" == *"oneshot"* ]]; then
+        local ExecStart=$(read_multioption ExecStart)
 
-    # Start service 
-    if [ -z $Type ] || [[ "${Type,,}" == *"simple"* ]] ; then
-        COMMAND='nohup '"$ExecStart"' >>/dev/null 2>&1 &'
-    elif [[ "${Type,,}" == *"forking"* ]] || [[ "${Type,,}" == *"oneshot"* ]] ; then
-        COMMAND="$ExecStart"
+        while IFS=$'\n' read -a i; do
+            # ignore errors
+            $(eval echo "$i") || echo
+        done  <<< "${ExecStartPre[@]}"
+
+        while IFS=$'\n' read -a i; do
+            # ignore errors
+            $(eval echo "$i") || echo
+        done  <<< "${ExecStart[@]}"
+
+        while IFS=$'\n' read -a i; do
+            $(eval echo "$i")
+        done  <<< "${ExecStartPost[@]}"
+    elif [ -z $Type ] || [[ "${Type,,}" == *"simple"* ]] || [[ "${Type,,}" == *"notify"* ]] || [[ "${Type,,}" == *"forking"* ]] ; then
+        makepid=""
+        [ -z "$PIDFile" ] && PIDFile="/run/$UNIT_NAME.pid" && makepid="--make-pidfile"
+        [ -f "$EnvironmentFile" ] && source "$EnvironmentFile"
+
+        cmd=("/usr/bin/start-stop-daemon --background --start --pidfile $PIDFile $makepid")
+
+        [ -f "$WorkingDirectory" ] && cmd+=("--chdir $WorkingDirectory")
+        [ -f "$User" ] && cmd+=("--chuid $User")
+
+        cmd+=(--exec "${ExecStart[0]}" -- "${ExecStart[@]:1}")
+
+        while IFS=$'\n' read -a i; do
+            # ignore errors
+            $(eval echo "$i") || echo
+        done  <<< "${ExecStartPre[@]}"
+
+        $(eval echo "${cmd[@]}")
+
+        while IFS=$'\n' read -a i; do
+            # ignore errors
+            $(eval echo "$i") || echo
+        done  <<< "${ExecStartPost[@]}"
     else
         >&2 echo "Unknown service type $Type"
     fi
-
-    #[ -z $User ] || COMMAND="su $User -c \"$COMMAND\""
-
-    while IFS=$'\n' read -a i; do
-        eval $i
-    done  <<< "${ExecStartPre[@]}"
-
-    eval "$COMMAND"
-
-    while IFS=$'\n' read -a i; do
-        eval $i
-    done  <<< "${ExecStartPost[@]}"
 }
 
 function action_stop(){
-
-    # Find depended services
-    local UNIT_FILE=$1
-    local UNIT_WANTS=(`get_unit_wants $1`)
-    local UNIT_INSTANCE=$2
-
     # Load options 
-    local User=`read_option User $UNIT_FILE $UNIT_INSTANCE`
-    local Type=`read_option Type $UNIT_FILE $UNIT_INSTANCE`
-    local EnvironmentFile=`read_option EnvironmentFile $UNIT_FILE $UNIT_INSTANCE`
-    local ExecStopPre=(`read_option ExecStartPre $UNIT_FILE $UNIT_INSTANCE`)
-    local ExecStop=`read_option ExecStop $UNIT_FILE $UNIT_INSTANCE`
-    local ExecStopPost=(`read_option ExecStartPost $UNIT_FILE $UNIT_INSTANCE`)
-    local ExecStart=`read_option ExecStart $UNIT_FILE $UNIT_INSTANCE`
+    local User=$(read_option User)
+    local Type=$(read_option Type)
+    local PIDFile=$(read_option PIDFile)
+    local EnvironmentFile=$(read_option EnvironmentFile | sed 's/^-//')
+    local ExecStop=$(read_option ExecStop)
+    local ExecStopPre=$(read_multioption ExecStopPre)
+    local ExecStopPost=$(read_multioption ExecStopPost)
 
+    [ -z "$PIDFile" ] && PIDFile="/run/$UNIT_NAME.pid"
     [ -f "$EnvironmentFile" ] && source "$EnvironmentFile"
 
     # Stop service 
-    if [ -z $ExecStop ] ; then
-        COMMAND="pkill -TERM -P \$(pgrep -f \"$ExecStart\")"
+    if [ -z "$ExecStop" ] ; then
+        cmd="/usr/bin/start-stop-daemon --stop --pidfile $PIDFile"
     else
-        COMMAND="$ExecStop"
+        cmd="$ExecStop"
     fi
 
-    #[ -z $User ] || COMMAND="su $User -c \"$COMMAND\""
-
     while IFS=$'\n' read -a i; do
-        eval $i
+        # ignore errors
+        $(eval echo "$i") || echo
     done  <<< "${ExecStopPre[@]}"
 
-    eval "$COMMAND"
+    $(eval echo "${cmd[@]}")
 
     while IFS=$'\n' read -a i; do
-        eval $i
+        # ignore errors
+        $(eval echo "$i") || echo
     done  <<< "${ExecStopPost[@]}"
 }
 
 function action_restart(){
-    local UNIT_FILE=$1
-    local UNIT_INSTANCE=$2
-
-    action_start $UNIT_FILE $UNIT_INSTANCE
-    action_stop $UNIT_FILE $UNIT_INSTANCE
+    action_start
+    sleep 1
+    action_stop
 }
 
-
 function action_enable(){
-
-    local UNIT_FILE=$1
-    local UNIT=`basename $UNIT_FILE`
-    local UNIT_INSTANCE=$2
-    local UNIT_FULL=`echo $UNIT | sed "s/@/@$UNIT_INSTANCE/"`
-
-    local WantedBy=`read_option WantedBy $UNIT_FILE`
+    local WantedBy=$(read_option WantedBy)
 
     if [ -z $WantedBy ] ; then
         >&2 echo "Unit $UNIT have no WantedBy option."
@@ -164,19 +178,12 @@ function action_enable(){
     if [ ! -f "$WANTEDBY_DIR/$UNIT_FULL" ] ; then
         mkdir -p $WANTEDBY_DIR
         echo Created symlink from $WANTEDBY_DIR/$UNIT_FULL to $UNIT_FILE.
-        ln -s $WANTEDBY_DIR/$UNIT_FULL $UNIT_FILE
+        ln -s $UNIT_FILE $WANTEDBY_DIR/$UNIT_FULL
     fi
-    
 }
     
 function action_disable(){
-
-    local UNIT_FILE=$1
-    local UNIT=`basename $UNIT_FILE`
-    local UNIT_INSTANCE=$2
-    local UNIT_FULL=`echo $UNIT | sed "s/@/@$UNIT_INSTANCE/"`
-
-    local WantedBy=`read_option WantedBy $UNIT_FILE`
+    local WantedBy=$(read_option WantedBy)
 
     if [ -z $WantedBy ] ; then
         >&2 echo "Unit $UNIT have no WantedBy option."
@@ -187,49 +194,165 @@ function action_disable(){
 
     if [ -f "$WANTEDBY_DIR/$UNIT_FULL" ] ; then
         echo Removed $WANTEDBY_DIR/$UNIT_FULL.
-        rm -f $WANTEDBY_DIR/$UNIT_FULL.
+        rm -f $WANTEDBY_DIR/$UNIT_FULL
         rmdir --ignore-fail-on-non-empty $WANTEDBY_DIR
     fi
-    
+}
+
+function action_isenabled(){
+    local WantedBy=$(read_option WantedBy)
+
+    if [ -z $WantedBy ] ; then
+        echo "unknown"
+    else
+        local WANTEDBY_DIR="/etc/systemd/system/$WantedBy.wants"
+        if [ -f "$WANTEDBY_DIR/$UNIT_FULL" ] ; then
+            echo "enabled"
+            exit 0
+        else
+            echo "disabled"
+            exit 1
+        fi
+    fi
+}
+
+function action_isactive(){
+    pid=$(_get_pid)
+
+    # set default pifile
+    [ "$pid" == "-1" ] && echo "unknown" && exit 3
+
+    # check if the pid exists - systemctl returns 3
+    kill -0 $pid > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        echo "active"
+        exit 0
+    else
+        echo "failed"
+        exit 3
+    fi
+}
+
+function _get_pid(){
+    local PIDFile=$(read_option PIDFile)
+
+    # set default pifile
+    [ -z "$PIDFile" ] && PIDFile="/run/$UNIT_NAME.pid"
+
+    # now check if the pidfile exists
+    if [ ! -f "$PIDFile" ]; then
+        echo "-1"
+    else
+        cat $PIDFile
+    fi
+}
+
+function action_status(){
+    local Description=$(read_option Description)
+    local Documentation=$(read_option Documentation)
+    pid=$(_get_pid)
+    isenabled=$(action_isenabled)
+    isactive=$(action_isactive)
+    status="inactive (dead)"
+    if [ $isactive == "failed" ]; then
+        status="failed (Result: not_implemented)"
+    elif [ $isactive == "active" ]; then
+        psdate=$(ps -p $pid -o lstart=)
+        pscmd=($(ps -p $pid -o cmd=))
+        psmem=$(ps -p $pid -o %mem= | tr -d ' ')
+        status="active (running) since $psdate"
+    fi
+
+    echo "● $UNIT - $Description"
+    echo "   Loaded: loaded ($UNIT_FILE; $isenabled; vendor preset: not_implemented)"
+    echo "   Active: $status"
+    if [ $isactive == "active" ]; then
+        if [ ! -z $Documentation ]; then
+          echo "     Docs: $Documentation"
+        fi
+        echo " Main PID: $pid ($(basename ${pscmd[0]}))"
+        echo "   Memory: $psmem%"
+        echo "   CGroup: /system.slice/$UNIT"
+        echo "           └─$pid ${pscmd[@]}"
+    fi
+    echo
 }
 
 function exec_action(){
-
     local ACTION=$1
     local UNIT=$2
-    
+
     [[ $UNIT =~ '.' ]] || UNIT="$UNIT.service"
+
+    local UNIT_NAME=$(echo $UNIT | cut -d '.' -f1)
 
     if [[ $UNIT =~ '@' ]] ; then
         local UNIT_INSTANCE=`echo $UNIT | cut -d'@' -f2- | cut -d. -f1`
         local UNIT=`echo $UNIT | sed "s/$UNIT_INSTANCE//"`
     fi
 
-    UNIT_FILE=`get_unit_file $UNIT`
+    local UNIT_FILE=`get_unit_file $UNIT`
+    local UNIT_FULL=`echo $UNIT | sed "s/@/@$UNIT_INSTANCE/"`
+    local UNIT_WANTS=(`get_unit_wants $UNIT`)
+
+    # Systemd env variables
+    # https://www.freedesktop.org/software/systemd/man/systemd.service.html
+    local MAINPID=$(_get_pid)
 
     if [ -z $UNIT_FILE ] ; then
         >&2 echo "Failed to $ACTION $UNIT: Unit $UNIT not found."
         exit 1
     else
         case "$ACTION" in
-            start )     action_start $UNIT_FILE $UNIT_INSTANCE ;;
-            stop )      action_stop $UNIT_FILE $UNIT_INSTANCE ;;
-            restart )   action_restart $UNIT_FILE $UNIT_INSTANCE ;;
-            enable )    action_enable $UNIT_FILE $UNIT_INSTANCE ;;
-            disable )   action_disable $UNIT_FILE $UNIT_INSTANCE ;;
-            * ) >&2 echo "Unknown operation $ACTION." ; exit 1 ;;
+            status )    action_status ;;
+            start )     action_start ;;
+            stop )      action_stop ;;
+            restart )   action_restart ;;
+            enable )    action_enable ;;
+            disable )   action_disable ;;
+            is-active ) action_isactive ;;
+            is-enabled ) action_isenabled ;;
+            help ) >&2 echo "This command expects one or more unit names. Did you mean --help?" ; exit 1 ;;
+            -h ) echo $USAGE ; exit 0 ;;
+            --help ) echo $USAGE ; exit 0 ;;
+            # exit 0 if unknown operation to avoid errors
+            # like mask, unmask etc
+            * ) >&2 echo "Unknown operation '$ACTION'" ; exit 0 ;;
         esac
     fi
 }
 
-ACTION="$1"
-UNITS="${@:2}"
-UNIT_PATHS=(
-    /etc/systemd/system/
-    /usr/lib/systemd/system/
-)
+function main(){
 
+    local USAGE="systemctl [OPTIONS...] {COMMAND} ...
 
-for UNIT in ${UNITS[@]}; do
-    exec_action $ACTION $UNIT
-done
+Query or send control commands to the systemd manager.
+
+  -h --help           Show this help
+
+Unit Commands:
+  start NAME...                   Start (activate) one or more units
+  stop NAME...                    Stop (deactivate) one or more units
+  restart NAME...                 Start or restart one or more units
+  is-active PATTERN...            Check whether units are active
+  status [PATTERN...|PID...]      Show runtime status of one or more units
+
+Unit File Commands:
+  enable NAME...                  Enable one or more unit files
+  disable NAME...                 Disable one or more unit files
+  is-enabled NAME...              Check whether unit files are enabled
+"
+
+    local ACTION="$1"
+    local UNITS="${@:2}"
+    local UNIT_PATHS=(
+        /etc/systemd/system/
+        /usr/lib/systemd/system/
+    )
+
+    for UNIT in ${UNITS[@]}; do
+        exec_action $ACTION $UNIT
+    done
+}
+
+main $@


### PR DESCRIPTION
Hello,

Again thanks for your script, you saved me lot of time.

But for my usage, I did lot changes. Here is the this MR to open a discussion about what I did and what you expect. I'm fully open, don't hesitate :)

I replaced nohub and exec by start-stop-daemon.c from Marek Michalkiewicz <marekm@i17linuxb.ists.pwr.wroc.pl>. A copy here  https://github.com/daleobrien/start-stop-daemon 

Added a status who mime the status of systemd plus is-enabled and is-disabled
Added an usage
Support User, Optional EnvironmentFile, Pidfile, several execstartpre/post on multiline or not.

I removed all duplicate local UNIT* declaration, because you could define them in exec_action action and reuse them in functions (more readable).

Some vars are upper (global), lower (local) and camelcase (systemd options).

I added a dockerfile because i use fake-systemd to test somes config management modules (puppet, ansible etc) in a container without privileges.

Fixed the bug with enable service (wrong order in ln -s)

Eval command to allow var from envfile or systemd vars to be replaced.

